### PR TITLE
add version command. add log entry if using openaip data.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs: # basic units of work in a run
       - run:
           name: Run unit tests
           # store the results of our tests in the $TEST_RESULTS directory
-          command: TESTOPTIONS="-v " make build-airtrack-linux-amd64
+          command: TESTOPTIONS="-v " RELEASE_LDFLAGS="-X github.com/afk11/airtrack/pkg/cmd/airtrack.version=${CIRCLE_TAG} -X github.com/afk11/airtrack/pkg/cmd/airtrack.usingOpenAipData=y" make build-airtrack-linux-amd64
       - run:
           name: Copy build artifacts
           command: |

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ TAR1090_VERSION=a0491945db41aaa7d49df2951ce1019968048046
 READSB_VERSION=4815cbe7441ae045890b9adfac3426b93b7b8d75
 READSB_REPO=https://github.com/afk11/readsb-protobuf
 PROTOBUF_C_VERSION=v1.3.3
+AIRTRACK_COMMIT = $(shell git rev-parse HEAD)
+AIRTRACK_LDFLAGS = "-X github.com/afk11/airtrack/pkg/cmd/airtrack.commit=$(AIRTRACK_COMMIT) $(RELEASE_LDFLAGS)"
 
 install-go-bindata:
 		go get -u github.com/jteeuwen/go-bindata/...
@@ -56,7 +58,7 @@ build-dir-airports: build-dir
 		go run ./contrib/copy_airport_resources/main.go resources/airports
 build-deps: build-protobuf build-bindata build-easyjson
 build-airtrack-linux-amd64: delete-build-dir resources/readsb-src build-deps
-		CGO_ENABLED=1 GO111MODULE=on GOOS=linux GOARCH=amd64 go $(BUILDARGS) build -o airtrack.linux-amd64 cmd/airtrack/main.go
+		CGO_ENABLED=1 GO111MODULE=on GOOS=linux GOARCH=amd64 go $(BUILDARGS) build -ldflags $(AIRTRACK_LDFLAGS) -o airtrack.linux-amd64 cmd/airtrack/main.go
 build-airtrack-qa-linux-amd64: delete-build-dir resources/readsb-src build-deps
 		CGO_ENABLED=1 GO111MODULE=on GOOS=linux GOARCH=amd64 go $(BUILDARGS) build -o airtrackqa.linux-amd64 cmd/airtrack-qa/main.go
 

--- a/cmd/airtrack/main.go
+++ b/cmd/airtrack/main.go
@@ -6,6 +6,8 @@ import (
 )
 
 var cli struct {
+	Version airtrack.VersionCmd `cmd help:"Prints version information"`
+
 	Track airtrack.TrackCmd `cmd help:"Track aircraft"`
 
 	Migrate struct {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - Include openAIP data with distributed releases
+ - Add `version` command to airtrack

--- a/pkg/cmd/airtrack/track.go
+++ b/pkg/cmd/airtrack/track.go
@@ -40,6 +40,8 @@ import (
 	"time"
 )
 
+var usingOpenAipData string
+
 // TrackCmd - aircraft tracking task
 type TrackCmd struct {
 	// Config - aircraft configuration file path
@@ -245,6 +247,9 @@ func (l *Loader) Load(c *TrackCmd) error {
 	var airportsFound int
 	useBuiltinAirports := l.cfg.Airports == nil || l.cfg.Airports.DisableBuiltInAirports == false
 	if useBuiltinAirports {
+		if usingOpenAipData != "" {
+			log.Infof("using airport location data from openaip.net")
+		}
 		airportAssetFiles := airports.AssetNames()
 		airportFiles += len(airportAssetFiles)
 		for i := range airportAssetFiles {

--- a/pkg/cmd/airtrack/version.go
+++ b/pkg/cmd/airtrack/version.go
@@ -1,0 +1,32 @@
+package airtrack
+
+import (
+	"fmt"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+var version string
+var commit string
+
+type (
+	VersionCmd struct{}
+)
+
+func (c *VersionCmd) Run() error {
+	if version == "" {
+		_, err := fmt.Printf("airtrack development version\n")
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := fmt.Printf("airtrack version %s\n", version)
+		if err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Printf("  revision: %s\n", commit)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Adds a `version` command to airtrack which prints git tag / commit information

Also adds a log line when users are using the released airtrack version with openaip data.
