### PR TITLE
beast_producer: fixup, should actually reconnect if network drops

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -52,3 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixes deadlock in tracker/map.go:updateJSON. Release projMu ASAP since ProjectHistory
    also needs it. Debugged using go-deadlock.
  - BEAST Server configuration: default to 30005 if nothing provided
+
+## [0.0.5] - 2020-12-17
+
+### Changed
+
+ - `#62`: Fixed beast_producer so it reconnects if the network drops

--- a/pkg/tracker/beast_producer.go
+++ b/pkg/tracker/beast_producer.go
@@ -82,7 +82,7 @@ func (p *BeastProducer) producer(ctx context.Context) {
 			fmt.Sprintf("%s:%d", p.host, p.port), time.Second*5)
 		if err != nil {
 			select {
-			case <-time.After(time.Second * 30):
+			case <-time.After(time.Second * 10):
 				continue
 			case <-ctx.Done():
 				return
@@ -101,14 +101,12 @@ func (p *BeastProducer) producer(ctx context.Context) {
 			err = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
 			if err != nil {
 				_ = conn.Close()
-				// Sleep for 30 seconds and attempt to reconnect, or quit
-				// if we received the quit signal.
 				select {
-				case <-time.After(time.Second * 30):
-					continue
+				default:
 				case <-ctx.Done():
 					return
 				}
+				break // not continue, want outer loop to rerun
 			}
 
 			m := 1024
@@ -117,14 +115,12 @@ func (p *BeastProducer) producer(ctx context.Context) {
 			_, err := conn.Read(recvBuf[:]) // recv data
 			if err != nil {
 				_ = conn.Close()
-				// Sleep for 30 seconds and attempt to reconnect, or quit
-				// if we received the quit signal.
 				select {
-				case <-time.After(time.Second * 30):
-					continue
+				default:
 				case <-ctx.Done():
 					return
 				}
+				break // not continue, we want outer loop to rerun
 			}
 
 			// append receivedData to connection buffer for leftovers from

--- a/pkg/tracker/tracker_test.go
+++ b/pkg/tracker/tracker_test.go
@@ -153,8 +153,8 @@ func TestTracker_AddProject(t *testing.T) {
 		c := make(chan *pb.Message)
 		database := db.NewDatabase(dbConn, dialect)
 		tr := startTracker(database, c, Options{
-			SightingTimeout:        time.Second * 30,
-			LocationUpdateInterval: time.Second * 15,
+			SightingTimeout:         time.Second * 30,
+			LocationUpdateInterval:  time.Second * 15,
 			OnGroundUpdateThreshold: 1,
 		})
 
@@ -177,8 +177,8 @@ func TestTracker_AddProject(t *testing.T) {
 		c := make(chan *pb.Message)
 		database := db.NewDatabase(dbConn, dialect)
 		tr := startTracker(database, c, Options{
-			SightingTimeout:        time.Second * 30,
-			LocationUpdateInterval: time.Second * 15,
+			SightingTimeout:         time.Second * 30,
+			LocationUpdateInterval:  time.Second * 15,
 			OnGroundUpdateThreshold: 1,
 		})
 


### PR DESCRIPTION
Simple tests were indicating that beast_producer's reconnect logic was faulty. This was tracked down to the two `continue` statements in the inner for loop. Because these kept endlessly looping, the connection was never recreated.